### PR TITLE
Security patch for RegEx DoS exploit

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   ],
   "main": "./lib/cradle",
   "dependencies": {
-    "follow": "0.11.x",
+    "follow": "https://github.com/shirakaba/follow/tarball/shirakaba-security-redos",
     "request": "2.x.x",
     "vargs": "0.1.0"
   },


### PR DESCRIPTION
From https://nodesecurity.io/advisories/534 :

OVERVIEW

Affected versions of debug are vulnerable to regular expression denial of service when untrusted user input is passed into the o formatter.

As it takes 50,000 characters to block the event loop for 2 seconds, this issue is a low severity issue.

REMEDIATION

Version 2.x.x: Update to version 2.6.9 or later. Version 3.x.x: Update to version 3.1.0 or later.